### PR TITLE
[FEAT] api 타입 지정 및 작성 페이지 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-*.env

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import MyCalendar from './mypage/components/Calendar';
 import LandingPage from '@landing/LandingPage';
 import CommunityAll from './community/category/CommunityAll';
 import Footer from './footer/Footer';
+import CreatePost from './community/form/CreatePost';
+import CommunityFree from './community/category/CommunityFree';
+import CommunityShare from './community/category/CommunityShare';
 
 function App() {
   return (
@@ -18,13 +21,14 @@ function App() {
       <main>
         <Routes>
           <Route path="/" element={<LandingPage />} />
+          <Route path="/community/create" element={<CreatePost />} />
           <Route path="/community" element={<CommunityLayout />}>
-            <Route path="all" element={<CommunityAll />} />
-            {/* <Route path="free" element={<CommunityFree />} /> */}
-            {/* <Route path="share" element={<CommunityShare />} />
+            <Route index element={<CommunityAll />} />
+            {/* <Route path="free" element={<CommunityFree />} />
+            <Route path="share" element={<CommunityShare />} />
             <Route path="study" element={<CommunityStudy />} /> */}
           </Route>
-          <Route path="/" element={<LandingPage />} />
+
           <Route path="/login" element={<Login />} />
           <Route path="/mypage" element={<MyPage />}>
             <Route index element={<MypageContent />} />

--- a/src/community/CommunityLayout.tsx
+++ b/src/community/CommunityLayout.tsx
@@ -1,7 +1,8 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import CommunityTab from './components/CommunityTab';
 import SidebarRanking from './components/SidebarRanking';
 import CommunityAll from './category/CommunityAll';
+import CreatePostButton from './components/CreatePostButton';
 
 const dummyfreePost = [
   { id: 1, title: '오늘 날씨가 좋아요' },
@@ -29,6 +30,19 @@ const dummySharePost = [
 // 더미데이터로 구현 확인
 
 const CommunityLayout = () => {
+  const location = useLocation();
+
+  const category: 'free' | 'share' | 'study' = location.pathname.includes('/share')
+    ? 'share'
+    : location.pathname.includes('/study')
+      ? 'study'
+      : 'free';
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   return (
     <div className="w-full flex justify-center px-4 pt-30">
       <div className="w-full max-w-[1000px]">
@@ -48,10 +62,15 @@ const CommunityLayout = () => {
           </div>
 
           {/* 본문 */}
-          <div className="flex-1 max-w-[600px]">
-            <CommunityAll />
+          <main className="flex-1 max-w-[600px]">
+            <div className="text-sm text-gray-700" />
             <Outlet />
-          </div>
+          </main>
+          <CreatePostButton
+            category={category}
+            to="/community/create"
+            className="inline-flex self-start h-9 px-3 py-1 rounded-lg"
+          />
         </div>
       </div>
     </div>

--- a/src/community/api/community.ts
+++ b/src/community/api/community.ts
@@ -1,25 +1,98 @@
-import { postJSON } from './http';
-import type { BasePostPayload, CommentPayload, CommentResponse, PostResponse } from './types';
+import { http } from './http';
+import {
+  FreePostRequestDTO,
+  FreePostResponseDTO,
+  FreePostUpdateRequestDTO,
+  SharePostRequestDTO,
+  SharePostResponseDTO,
+  SharePostUpdateRequestDTO,
+  StudyPostRequestDTO,
+  StudyPostResponseDTO,
+  StudyPostUpdateRequestDTO,
+  CommentResponseDTO,
+} from './types';
 
-export function createFreePost(body: BasePostPayload) {
-  return postJSON<BasePostPayload, PostResponse>('/api/community/post/free', body);
-}
+export const createFreePost = (body: FreePostRequestDTO) =>
+  http<FreePostResponseDTO>('/api/community/post/free', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
 
-export function createSharePost(body: BasePostPayload) {
-  return postJSON<BasePostPayload, PostResponse>('/api/community/post/share', body);
-}
+export const getFreePost = (postId: number) =>
+  http<FreePostResponseDTO>(`/api/community/post/free/${postId}`);
 
-export function createStudyPost(body: BasePostPayload) {
-  return postJSON<BasePostPayload, PostResponse>('/api/community/post/study', body);
-}
+export const patchFreePost = (postId: number, body: FreePostUpdateRequestDTO, userId?: number) =>
+  http<FreePostResponseDTO>(`/api/community/post/free/${postId}`, {
+    method: 'PATCH',
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+    body: JSON.stringify(body),
+  });
 
-export function addComment(postId: number, body: CommentPayload) {
-  return postJSON<CommentPayload, CommentResponse>(`/api/community/post/${postId}/comment`, body);
-}
+export const createSharePost = (body: SharePostRequestDTO) =>
+  http<SharePostResponseDTO>('/api/community/post/share', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
 
-export function joinStudy(postId: number, payload?: { note?: string }) {
-  return postJSON<typeof payload, { joined: true; postId: number }>(
-    `/api/community/post/study/${postId}/join`,
-    payload ?? {},
-  );
-}
+export const getSharePost = (postId: number) =>
+  http<SharePostResponseDTO>(`/api/community/post/share/${postId}`);
+
+export const patchSharePost = (postId: number, body: SharePostUpdateRequestDTO, userId?: number) =>
+  http<SharePostResponseDTO>(`/api/community/post/share/${postId}`, {
+    method: 'PATCH',
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+    body: JSON.stringify(body),
+  });
+
+export const createStudyPost = (body: StudyPostRequestDTO) =>
+  http<StudyPostResponseDTO>('/api/community/post/study', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+export const getStudyPost = (postId: number) =>
+  http<StudyPostResponseDTO>(`/api/community/post/study/${postId}`);
+
+export const patchStudyPost = (postId: number, body: StudyPostUpdateRequestDTO, userId?: number) =>
+  http<StudyPostResponseDTO>(`/api/community/post/study/${postId}`, {
+    method: 'PATCH',
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+    body: JSON.stringify(body),
+  });
+
+export const joinStudyPost = (postId: number, userId: number) =>
+  http<void>(`/api/community/post/study/${postId}/join`, {
+    method: 'POST',
+    body: JSON.stringify({ user_id: userId }),
+  });
+
+export const createComment = (postId: number, content: string, userId: number, parentId?: number) =>
+  http<CommentResponseDTO>(`/api/community/post/${postId}/comment`, {
+    method: 'POST',
+    body: JSON.stringify({
+      post_id: postId,
+      content,
+      user_id: userId,
+      parent_id: parentId ?? null,
+    }),
+  });
+
+export const readLikeCount = (postId: number) =>
+  http<unknown>(`/api/community/post/${postId}/likes`);
+
+export const toggleLike = (postId: number, userId?: number) =>
+  http<void>(`/api/community/post/${postId}/like`, {
+    method: 'POST',
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+  });
+
+export const likeStatus = (postId: number, userId?: number) =>
+  http<unknown>(`/api/community/post/${postId}/like/status`, {
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+  });
+
+export const deletePost = (postId: number, userId?: number) =>
+  http<void>(`/api/community/post/${postId}`, {
+    method: 'DELETE',
+    headers: { ...(userId ? { x_user_id: String(userId) } : {}) },
+  });

--- a/src/community/api/http.ts
+++ b/src/community/api/http.ts
@@ -1,17 +1,17 @@
-export async function postJSON<TReq, TRes>(
-  url: string,
-  body: TReq,
-  init?: RequestInit,
-): Promise<TRes> {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'applocation/json' },
-    body: JSON.stringify(body),
+const BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export async function http<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
     ...init,
   });
   if (!res.ok) {
-    const msg = await res.text().catch(() => '');
-    throw new Error(msg || `POST ${url} failed (${res.status})`);
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText} ${text}`);
   }
-  return res.json() as Promise<TRes>;
+  try {
+    return await res.json();
+  } catch {
+    return undefined as T;
+  }
 }

--- a/src/community/api/http.ts
+++ b/src/community/api/http.ts
@@ -1,17 +1,28 @@
-const BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+// const BASE = import.meta.env.VITE_API_BASE_URL ?? '';
 
-export async function http<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
-    ...init,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`${res.status} ${res.statusText} ${text}`);
-  }
-  try {
-    return await res.json();
-  } catch {
-    return undefined as T;
-  }
-}
+// export async function http<T>(url: string, init: RequestInit = {}): Promise<T> {
+//   const method = (init.method ?? 'GET').toUpperCase();
+//   const isSimpleGet = method === 'GET' || method === 'HEAD';
+
+//   const headers: Record<string, string> = {
+//     Accept: 'application/json',
+//     ...(init.headers as Record<string, string> | undefined),
+//   };
+//   if (!isSimpleGet && !headers['Content-Type']) {
+//     headers['Content-Type'] = 'application/json';
+//   }
+
+//   const res = await fetch(`${BASE}${url}`, {
+//     ...init,
+//     method,
+//     headers,
+//     redirect: 'follow',
+//   });
+
+//   if (!res.ok) {
+//     const text = await res.text().catch(() => '');
+//     throw new Error(`${res.status} ${res.statusText} ${text ? `- ${text}` : ''}`);
+//   }
+//   if (res.status === 204) return undefined as unknown as T;
+//   return (await res.json()) as T;
+// }

--- a/src/community/api/types.ts
+++ b/src/community/api/types.ts
@@ -1,53 +1,105 @@
-export type PostCategory = 'all' | 'share' | 'study' | 'free';
-
-export interface Post {
-  postId: number;
-  title: string;
-  author: string;
-  authorId: number;
-  category: 'free' | 'share' | 'study';
-  content: string;
-  createdAt: string;
-  viewCount: number;
-  likeCount: number;
-  commentCount: number;
-
-  recruitStart?: string;
-  recruitEnd?: string;
-  studyStart?: string;
-  studyEnd?: string;
-  maxMembers?: number;
-}
-
-export interface BasePostPayload {
+export interface FreePostRequestDTO {
   title: string;
   content: string;
+  user_id: number;
+  category?: 'free';
 }
-
-export interface StudyPostPatload extends BasePostPayload {
-  recruitStart?: string;
-  recruitEnd?: string;
-  studyStart?: string;
-  studyEnd?: string;
-  maxMember?: number;
+export interface FreeBoardResponseDTO {
+  image_url: string | null;
 }
-
-export interface PostResponse {
-  postId: number;
+export interface FreePostResponseDTO {
+  id: number;
   title: string;
-  authorId: number;
-  category: PostCategory;
-  createdAt: string;
+  content: string;
+  category: 'free';
+  author_id: number;
+  views: number;
+  free_board: FreeBoardResponseDTO;
+  created_at: string;
+  updated_at: string;
 }
 
-export interface CommentPayload {
+export interface SharePostRequestDTO {
+  title: string;
   content: string;
+  user_id: number;
+  file_url?: string | null;
+  category?: 'share';
+}
+export interface DataShareResponseDTO {
+  file_url: string | null;
+}
+export interface SharePostResponseDTO {
+  id: number;
+  title: string;
+  content: string;
+  category: 'share';
+  author_id: number;
+  views: number;
+  data_share: DataShareResponseDTO;
+  created_at: string;
+  updated_at: string;
 }
 
-export interface CommentResponse {
-  commentId: number;
-  postId: number;
+export interface StudyPostRequestDTO {
+  title: string;
   content: string;
-  author: string;
-  createdAt: string;
+  user_id: number;
+  category?: 'study';
+  recruit_start: string; // ISO
+  recruit_end: string;
+  study_start: string;
+  study_end: string;
+  max_member: number;
+}
+export interface StudyRecruitmentResponseDTO {
+  recruit_start: string;
+  recruit_end: string;
+  study_start: string;
+  study_end: string;
+  max_member: number;
+}
+export interface StudyPostResponseDTO {
+  id: number;
+  title: string;
+  content: string;
+  category: 'study';
+  author_id: number;
+  views: number;
+  study_recruitment: StudyRecruitmentResponseDTO;
+  created_at: string;
+  updated_at: string;
+}
+
+export type FreePostUpdateRequestDTO = Partial<Pick<FreePostRequestDTO, 'title' | 'content'>>;
+export type SharePostUpdateRequestDTO = Partial<Pick<SharePostRequestDTO, 'title' | 'content'>> & {
+  file_url?: string | null;
+};
+export type StudyPostUpdateRequestDTO = Partial<
+  Pick<
+    StudyPostRequestDTO,
+    | 'title'
+    | 'content'
+    | 'recruit_start'
+    | 'recruit_end'
+    | 'study_start'
+    | 'study_end'
+    | 'max_member'
+  >
+>;
+
+export interface CommentRequestDTO {
+  post_id: number;
+  content: string;
+  parent_id?: number | null;
+  user_id: number;
+}
+export interface CommentResponseDTO {
+  id: number;
+  post_id: number;
+  content: string;
+  author_id: number;
+  parent_id: number | null;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/community/api/types.ts
+++ b/src/community/api/types.ts
@@ -24,6 +24,7 @@ export interface SharePostRequestDTO {
   content: string;
   user_id: number;
   file_url?: string | null;
+  img_url?: string | null;
   category?: 'share';
 }
 export interface DataShareResponseDTO {
@@ -46,7 +47,7 @@ export interface StudyPostRequestDTO {
   content: string;
   user_id: number;
   category?: 'study';
-  recruit_start: string; // ISO
+  recruit_start: string;
   recruit_end: string;
   study_start: string;
   study_end: string;

--- a/src/community/category/CommunityFree.tsx
+++ b/src/community/category/CommunityFree.tsx
@@ -1,32 +1,6 @@
-// import { useNavigate } from 'react-router-dom';
-// import { useCommunityPosts } from '../hook/useCommunityPosts';
-// import PostCard from '../components/Postcard';
-// import type { Post } from '../api/community';
+const CommunityFree = () => {
+  return;
+  <></>;
+};
 
-// const CommunityFree = () => {
-//   const navigate = useNavigate();
-//   const { data: posts, isLoading } = useCommunityPosts('free');
-
-//   const currentUserId = 723;
-
-//   return (
-//     <div className="flex flex-col gap-4 w-full">
-//       {isLoading ? (
-//         <p className="text-[#0180F5]">불러오는 중...</p>
-//       ) : posts && posts.length > 0 ? (
-//         posts.map((post: Post) => (
-//           <PostCard
-//             key={post.postId}
-//             post={post}
-//             currentUserId={currentUserId}
-//             onClick={(id) => navigate(`/community/post/${id}`)}
-//           />
-//         ))
-//       ) : (
-//         <p className="text-black">게시글이 없습니다.</p>
-//       )}
-//     </div>
-//   );
-// };
-
-// export default CommunityFree;
+export default CommunityFree;

--- a/src/community/category/CommunityShare.tsx
+++ b/src/community/category/CommunityShare.tsx
@@ -1,30 +1,6 @@
-// import { useNavigate } from 'react-router-dom';
-// import PostCard from '../components/Postcard';
-// import type { Post } from '../api/community';
+const CommunityShare = () => {
+  return;
+  <></>;
+};
 
-// const CommunityShare = () => {
-//   const navigate = useNavigate();
-//   const { data: posts, isLoading } = useCommunityPosts('share');
-
-//   const currentUserId = 123;
-
-//   return (
-//     <div className="flex flex-col gap-4 w-full">
-//       {isLoading ? (
-//         <p className="text-gray-500">불러오는 중...</p>
-//       ) : posts && posts.length > 0 ? (
-//         posts.map((post: Post) => (
-//           <PostCard
-//             key={post.postId}
-//             post={post}
-//             currentUserId={currentUserId}
-//             onClick={(id) => navigate(`/community/post/${id}`)}
-//           />
-//         ))
-//       ) : (
-//         <p className="text-gray-400">게시글이 없습니다.</p>
-//       )}
-//     </div>
-//   );
-// };
-// export default CommunityShare;
+export default CommunityShare;

--- a/src/community/category/CommunityStudy.tsx
+++ b/src/community/category/CommunityStudy.tsx
@@ -1,30 +1,6 @@
-// import { useNavigate } from "react-router-dom"
-// import type { Post } from "../api/community"
-// import PostCard from "../components/Postcard"
+const CommunityStudy = () => {
+  return;
+  <></>;
+};
 
-// const CommunityStudy = () => {
-//     const navigate = useNavigate()
-//     const { data: posts, isLoading } = useCommunityPosts("study")
-
-//     const currentUserId = 123
-
-//     return (
-//         <div className="flex flex-col gap-4 w-full">
-//           {isLoading ? (
-//             <p className="text-gray-500">불러오는 중...</p>
-//           ) : posts && posts.length > 0 ? (
-//             posts.map((post:Post) => (
-//               <PostCard
-//                 key={post.postId}
-//                 post={post}
-//                 currentUserId={currentUserId}
-//                 onClick={(id) => navigate(`/community/post/${id}`)}
-//               />
-//             ))
-//           ) : (
-//             <p className="text-gray-400">스터디 게시글이 없습니다.</p>
-//           )}
-//         </div>
-//     )
-//   }
-//   export default CommunityStudy
+export default CommunityStudy;

--- a/src/community/components/CommunityTab.tsx
+++ b/src/community/components/CommunityTab.tsx
@@ -14,6 +14,7 @@ const CommunityTab = () => {
         <NavLink
           key={tab.path}
           to={tab.path}
+          end={tab.path === '/community'}
           className={({ isActive }) =>
             `text-m font-medium  pb-1 ps-7  ${
               isActive

--- a/src/community/components/CreatePostButton.tsx
+++ b/src/community/components/CreatePostButton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+type Cat = 'free' | 'share' | 'study';
+
+interface Props {
+  category: Cat;
+  to?: string;
+  as?: 'button' | 'link';
+  className?: string;
+  extraQuery?: Record<string, string | number | undefined>;
+}
+
+const baseClass =
+  'px-4 py-2 rounded-xl shadow hover:shadow-md bg-black text-white disabled:opacity-60 disabled:cursor-not-allowed';
+
+function buildHref(to: string, params: Record<string, string | number | undefined>) {
+  const qs = new URLSearchParams();
+  Object.entries(params).forEach(([k, v]) => {
+    if (v !== undefined && v !== '') qs.set(k, String(v));
+  });
+  const sep = to.includes('?') ? '&' : '?';
+  const query = qs.toString();
+  return query ? `${to}${sep}${query}` : to;
+}
+
+const CreatePostButton: React.FC<Props> = ({
+  category,
+  to = 'create',
+  as = 'button',
+  className,
+  extraQuery,
+}) => {
+  const navigate = useNavigate();
+  const href = buildHref(to, { category, ...(extraQuery || {}) });
+
+  if (as === 'link') {
+    return (
+      <Link to={href} className={`${baseClass} ${className ?? ''}`} aria-label="새 글 작성">
+        작성
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(href)}
+      className={`${baseClass} ${className ?? ''}`}
+      aria-label="새 글 작성"
+    >
+      작성
+    </button>
+  );
+};
+
+export default CreatePostButton;

--- a/src/community/components/Postcard.tsx
+++ b/src/community/components/Postcard.tsx
@@ -1,5 +1,23 @@
 import React, { FC } from 'react';
-import type { Post } from '../api/types';
+
+export interface Post {
+  postId: number;
+  title: string;
+  author: string;
+  authorId: number;
+  category: 'free' | 'share' | 'study';
+  content: string;
+  createdAt: string;
+  views: number;
+  likes: number;
+  comments: number;
+
+  recruitStart?: string;
+  recruitEnd?: string;
+  studyStart?: string;
+  studyEnd?: string;
+  maxMembers?: number;
+}
 
 interface PostCardProps {
   post: Post;
@@ -55,9 +73,9 @@ const PostCard: FC<PostCardProps> = ({ post, currentUserId, isAdmin = false, onC
         <p className="text-sm text-gray-700 mt-1 line-clamp-3">{post.content}</p>
       )}
       <div className="flex justify-end items-center mt-3 text-xs text-gray-500 gap-4">
-        <span>💬 {post.commentCount}</span>
-        <span>❤️ {post.likeCount}</span>
-        <span>👁 {post.viewCount}</span>
+        <span>💬 {post.comments}</span>
+        <span>❤️ {post.likes}</span>
+        <span>👁 {post.views}</span>
       </div>
     </div>
   );

--- a/src/community/components/Postcard.tsx
+++ b/src/community/components/Postcard.tsx
@@ -27,18 +27,18 @@ interface PostCardProps {
 }
 
 const PostCard: FC<PostCardProps> = ({ post, currentUserId, isAdmin = false, onClick }) => {
-  const canEdit = isAdmin || post.postId === currentUserId;
+  const canEdit = isAdmin || post.authorId === currentUserId;
 
   const handleCardClick = () => {
     onClick(post.postId);
   };
 
   const handleEditClick = (e: React.MouseEvent) => {
-    e.stopPropagation;
+    e.stopPropagation();
   };
 
   const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation;
+    e.stopPropagation();
   };
 
   return (

--- a/src/community/form/CreatePost.tsx
+++ b/src/community/form/CreatePost.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import PostForm, { PostFormValues } from './PostForm';
+import { useCreateFree, useCreateShare, useCreateStudy } from '../hook/useCommunityPosts';
+import { FreePostRequestDTO, SharePostRequestDTO, StudyPostRequestDTO } from '../api/types';
+
+const toISODate = (d?: string) => (d ? new Date(`${d}T00:00:00`).toISOString() : '');
+
+type Cat = 'free' | 'share' | 'study';
+
+export default function CreatePost() {
+  const navigate = useNavigate();
+  const [sp] = useSearchParams();
+
+  const initialCategory = (sp.get('category') as Cat) ?? 'free';
+
+  const [shareFileUrl, setShareFileUrl] = useState<string>('');
+  const [shareImgUrl, setshareImgUrl] = useState<string>('');
+
+  const currentUserId = 1001;
+
+  const freeMut = useCreateFree();
+  const shareMut = useCreateShare();
+  const studyMut = useCreateStudy();
+  const isPending = freeMut.isPending || shareMut.isPending || studyMut.isPending;
+
+  const errorMsg =
+    (freeMut.error as Error)?.message ||
+    (shareMut.error as Error)?.message ||
+    (studyMut.error as Error)?.message ||
+    '';
+
+  const initialValues: Partial<PostFormValues> = useMemo(
+    () => ({ category: initialCategory }),
+    [initialCategory],
+  );
+
+  const handleSubmit = useCallback(
+    async (v: PostFormValues) => {
+      try {
+        if (v.category === 'free') {
+          const body: FreePostRequestDTO = {
+            title: v.title,
+            content: v.content,
+            user_id: currentUserId,
+          };
+          const res = await freeMut.mutateAsync(body);
+          navigate(`/community/free/${res.id}`);
+          return;
+        }
+
+        if (v.category === 'share') {
+          const body: SharePostRequestDTO = {
+            title: v.title,
+            content: v.content,
+            user_id: currentUserId,
+            file_url: shareFileUrl || null,
+            img_url: shareImgUrl || null,
+          };
+          const res = await shareMut.mutateAsync(body);
+          navigate(`/community/share/${res.id}`);
+          return;
+        }
+
+        if (v.category === 'study') {
+          const body: StudyPostRequestDTO = {
+            title: v.title,
+            content: v.content,
+            user_id: currentUserId,
+            recruit_start: toISODate(v.recruitStart),
+            recruit_end: toISODate(v.recruitEnd),
+            study_start: toISODate(v.studyStart),
+            study_end: toISODate(v.studyEnd),
+            max_member: Number(v.maxMembers ?? 0),
+          };
+          const res = await studyMut.mutateAsync(body);
+          navigate(`/community/study/${res.id}`);
+          return;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [currentUserId, freeMut, shareMut, studyMut, navigate, shareFileUrl],
+  );
+
+  return (
+    <div className="p-6 max-w-[720px] mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">새 글 작성</h1>
+
+      <PostForm
+        initialValues={initialValues}
+        submitLabel="저장"
+        disabled={isPending}
+        onSubmit={handleSubmit}
+      />
+
+      {(initialValues.category ?? 'free') === 'share' && (
+        <div className="space-y-2 border-t pt-4 mt-2">
+          <label className="block text-sm">첨부 파일 URL (옵션)</label>
+          <input
+            className="w-full border rounded-lg px-3 py-2"
+            placeholder="https://..."
+            value={shareFileUrl}
+            onChange={(e) => setShareFileUrl(e.target.value)}
+            disabled={isPending}
+          />
+          {errorMsg && <div className="text-red-600 text-sm">저장 실패: {errorMsg}</div>}
+        </div>
+      )}
+
+      {(initialValues.category ?? 'free') !== 'share' && errorMsg && (
+        <div className="text-red-600 text-sm">저장 실패: {errorMsg}</div>
+      )}
+    </div>
+  );
+}

--- a/src/community/form/PostForm.tsx
+++ b/src/community/form/PostForm.tsx
@@ -99,9 +99,8 @@ export default function PostForm({
   const err = (k: keyof PostFormValues) => touched[k];
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} className="space-y-4 mt-20">
       <div>
-        <label>제목</label>
         <input
           name="title"
           value={values.title}
@@ -109,18 +108,21 @@ export default function PostForm({
           onBlur={onBlur('title')}
           placeholder="제목을 입력하세요"
           disabled={disabled}
+          className={`w-full border rounded-md px-3 py-3 ${
+            err('title') ? 'border-#1B3043' : 'border-#1B3043'
+          }`}
         />
         {err('title') && <p>{errors.title}</p>}
       </div>
 
       <div>
-        <label>카테고리</label>
         <select
           name="category"
           value={values.category}
           onChange={setField('category')}
           onBlur={onBlur('category')}
           disabled={disabled}
+          className="w-full border rounded-md px-3 py-2 border-#1B3043"
         >
           <option value="free">자유</option>
           <option value="share">자료 공유</option>
@@ -136,14 +138,17 @@ export default function PostForm({
           onBlur={onBlur('content')}
           placeholder="내용을 입력하세요"
           disabled={disabled}
+          className={`w-full border rounded-md px-3 py-2 min-h-[400px] ${
+            err('content') ? 'border-#1B3043' : 'border-gray-300'
+          }`}
         />
         {err('content') && <p>{errors.content}</p>}
       </div>
 
       {isStudy && (
-        <div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label>모집 시작일</label>
+            <label className="block text-sm font-medium mb-1">모집 시작일</label>
             <input
               type="date"
               name="recruitStart"
@@ -151,11 +156,12 @@ export default function PostForm({
               onChange={setField('recruitStart')}
               onBlur={onBlur('recruitStart')}
               disabled={disabled}
+              className="w-full border rounded-md px-3 py-2 border-gray-300"
             />
           </div>
 
           <div>
-            <label>모집 마감일</label>
+            <label className="block text-sm font-medium mb-1">모집 마감일</label>
             <input
               type="date"
               name="recruitEnd"
@@ -163,12 +169,15 @@ export default function PostForm({
               onChange={setField('recruitEnd')}
               onBlur={onBlur('recruitEnd')}
               disabled={disabled}
+              className={`w-full border rounded-md px-3 py-2 ${
+                err('recruitEnd') ? 'border-red-400' : 'border-gray-300'
+              }`}
             />
-            {err('recruitEnd') && <p>{errors.recruitEnd}</p>}
+            {err('recruitEnd') && <p className="mt-1 text-xs text-red-500">{errors.recruitEnd}</p>}
           </div>
 
           <div>
-            <label>스터디 시작일</label>
+            <label className="block text-sm font-medium mb-1">스터디 시작일</label>
             <input
               type="date"
               name="studyStart"
@@ -176,11 +185,12 @@ export default function PostForm({
               onChange={setField('studyStart')}
               onBlur={onBlur('studyStart')}
               disabled={disabled}
+              className="w-full border rounded-md px-3 py-2 border-gray-300"
             />
           </div>
 
           <div>
-            <label>스터디 종료일</label>
+            <label className="block text-sm font-medium mb-1">스터디 종료일</label>
             <input
               type="date"
               name="studyEnd"
@@ -188,12 +198,15 @@ export default function PostForm({
               onChange={setField('studyEnd')}
               onBlur={onBlur('studyEnd')}
               disabled={disabled}
+              className={`w-full border rounded-md px-3 py-2 ${
+                err('studyEnd') ? 'border-red-400' : 'border-gray-300'
+              }`}
             />
-            {err('studyEnd') && <p>{errors.studyEnd}</p>}
+            {err('studyEnd') && <p className="mt-1 text-xs text-red-500">{errors.studyEnd}</p>}
           </div>
 
-          <div>
-            <label>최대 인원</label>
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium mb-1">최대 인원</label>
             <input
               type="number"
               min={2}
@@ -202,14 +215,21 @@ export default function PostForm({
               onChange={setField('maxMembers')}
               onBlur={onBlur('maxMembers')}
               disabled={disabled}
+              className={`w-full border rounded-md px-3 py-2 ${
+                err('maxMembers') ? 'border-red-400' : 'border-gray-300'
+              }`}
             />
-            {err('maxMembers') && <p>{errors.maxMembers}</p>}
+            {err('maxMembers') && <p className="mt-1 text-xs text-red-500">{errors.maxMembers}</p>}
           </div>
         </div>
       )}
 
-      <div>
-        <button type="submit" disabled={disabled}>
+      <div className="flex justify-end gap-2">
+        <button
+          type="submit"
+          className="px-4 py-2 rounded-md bg-black text-white disabled:opacity-60"
+          disabled={disabled}
+        >
           {submitLabel}
         </button>
       </div>

--- a/src/community/hook/useCommunityPosts.ts
+++ b/src/community/hook/useCommunityPosts.ts
@@ -1,9 +1,40 @@
-// import { useQuery } from '@tanstack/react-query';
-// import { getPostsByCategory } from '../api/community';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  FreePostRequestDTO,
+  FreePostResponseDTO,
+  SharePostRequestDTO,
+  SharePostResponseDTO,
+  StudyPostRequestDTO,
+  StudyPostResponseDTO,
+} from '../api/types';
+import { createFreePost, createSharePost, createStudyPost } from '../api/community';
 
-// export const useCommunityPosts = (category: string) => {
-//   return useQuery({
-//     queryKey: ['posts', category],
-//     queryFn: () => getPostsByCategory(category),
-//   });
-// };
+export const useCreateFree = () => {
+  const queryClient = useQueryClient();
+  return useMutation<FreePostResponseDTO, Error, FreePostRequestDTO>({
+    mutationFn: (b) => createFreePost(b),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['list', 'free'] });
+    },
+  });
+};
+
+export const useCreateShare = () => {
+  const queryClient = useQueryClient();
+  return useMutation<SharePostResponseDTO, Error, SharePostRequestDTO>({
+    mutationFn: (b) => createSharePost(b),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['list', 'share'] });
+    },
+  });
+};
+
+export const useCreateStudy = () => {
+  const queryClient = useQueryClient();
+  return useMutation<StudyPostResponseDTO, Error, StudyPostRequestDTO>({
+    mutationFn: (b) => createStudyPost(b),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['list', 'study'] });
+    },
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,19 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 30_000, retry: 1 },
+    mutations: { retry: 0 },
+  },
+});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
📌 개요
- api 타입 지정
- 게시물 작성 페이지 구현

🔧 작업 내용
- api GET 작업하다가 깔끔하게 포기하고 작성 폼 구현
- 작성 버튼 누르면 작성 폼이 나오며, 카테고리 선택 후 게시글 작성 가능

## 📎 관련 이슈

- close #53 
