### PR TITLE
[FEAT] 게시물 상세페이지 및 댓글, 대댓글 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,10 @@ import CreatePost from './community/form/CreatePost';
 import CommunityFree from './community/category/CommunityFree';
 import CommunityShare from './community/category/CommunityShare';
 import AiPage from './ai/AiPage';
+import EditPost from './community/form/EditPost';
+import PostDetail from './community/post/components/CommentItem';
+import CommunityStudy from './community/category/CommunityStudy';
+import PostDetailMock from './community/post/PostDetail';
 
 function App() {
   return (
@@ -25,9 +29,11 @@ function App() {
           <Route path="/community/create" element={<CreatePost />} />
           <Route path="/community" element={<CommunityLayout />}>
             <Route index element={<CommunityAll />} />
-            {/* <Route path="free" element={<CommunityFree />} />
+            <Route path="free" element={<CommunityFree />} />
             <Route path="share" element={<CommunityShare />} />
-            <Route path="study" element={<CommunityStudy />} /> */}
+            <Route path="study" element={<CommunityStudy />} />
+            <Route path="/community/:category/:id" element={<PostDetailMock />} />
+            <Route path="/community/:category/:id/edit" element={<EditPost />} />
           </Route>
 
           <Route path="/login" element={<Login />} />

--- a/src/community/CommunityLayout.tsx
+++ b/src/community/CommunityLayout.tsx
@@ -1,7 +1,6 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import CommunityTab from './components/CommunityTab';
 import SidebarRanking from './components/SidebarRanking';
-import CommunityAll from './category/CommunityAll';
 import CreatePostButton from './components/CreatePostButton';
 
 const dummyfreePost = [

--- a/src/community/__mock__/dummyPost.ts
+++ b/src/community/__mock__/dummyPost.ts
@@ -1,6 +1,200 @@
-// src/Community/__mock__/dummyPosts.ts
+import { Post } from '../components/Postcard';
+import type { FreePostResponseDTO, SharePostResponseDTO, StudyPostResponseDTO } from '../api/types';
 
-import { Post } from '../api/types';
+// src/community/__mock__/dummy.ts
+
+// ---------- 공용 타입 ----------
+export type CommentTreeItem = {
+  id: number;
+  post_id: number;
+  content: string;
+  author_id: number;
+  parent_id: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const iso = (s: string) => new Date(s).toISOString();
+
+// ---------- 더미 글 데이터 ----------
+export const dummyFree: FreePostResponseDTO[] = [
+  {
+    id: 101,
+    title: '오늘 날씨가 좋아요',
+    content: '점심에 산책 어떰?',
+    category: 'free',
+    author_id: 2001,
+    views: 12,
+    free_board: { image_url: null },
+    created_at: iso('2025-08-08T10:00:00'),
+    updated_at: iso('2025-08-08T10:00:00'),
+  },
+  {
+    id: 102,
+    title: '무무의 잡담',
+    content: '오늘 너무 덥다…',
+    category: 'free',
+    author_id: 2002,
+    views: 34,
+    free_board: { image_url: 'https://picsum.photos/seed/free102/800/400' },
+    created_at: iso('2025-08-08T09:30:00'),
+    updated_at: iso('2025-08-08T09:30:00'),
+  },
+];
+
+export const dummyShare: SharePostResponseDTO[] = [
+  {
+    id: 201,
+    title: 'React 자료 모음.zip 공유합니다',
+    content: '공식 문서/정리/유튜브 링크 묶음',
+    category: 'share',
+    author_id: 2004,
+    views: 55,
+    data_share: { file_url: 'https://example.com/react-pack.zip' },
+    created_at: iso('2025-08-08T11:00:00'),
+    updated_at: iso('2025-08-08T11:00:00'),
+  },
+  {
+    id: 202,
+    title: '면접 질문 리스트',
+    content: 'FE/BE 공통 50문항',
+    category: 'share',
+    author_id: 2001,
+    views: 18,
+    data_share: { file_url: null },
+    created_at: iso('2025-08-07T13:00:00'),
+    updated_at: iso('2025-08-07T13:00:00'),
+  },
+];
+
+export const dummyStudy: StudyPostResponseDTO[] = [
+  {
+    id: 301,
+    title: 'React 스터디 주말 모집합니다',
+    content: '기초부터 실전까지 함께해요!',
+    category: 'study',
+    author_id: 2006,
+    views: 41,
+    study_recruitment: {
+      recruit_start: iso('2025-08-07T00:00:00'),
+      recruit_end: iso('2025-08-10T23:59:59'),
+      study_start: iso('2025-08-11T00:00:00'),
+      study_end: iso('2025-09-11T23:59:59'),
+      max_member: 6,
+    },
+    created_at: iso('2025-08-08T08:00:00'),
+    updated_at: iso('2025-08-08T08:00:00'),
+  },
+];
+
+// ---------- 더미 댓글 데이터 ----------
+export const dummyComments: Record<number, CommentTreeItem[]> = {
+  201: [
+    {
+      id: 5001,
+      post_id: 201,
+      content: '와 감사합니다!',
+      author_id: 3001,
+      parent_id: null,
+      created_at: iso('2025-08-08T11:10:00'),
+      updated_at: iso('2025-08-08T11:10:00'),
+    },
+    {
+      id: 5002,
+      post_id: 201,
+      content: '도움 많이 됐어요 🙏',
+      author_id: 3002,
+      parent_id: 5001,
+      created_at: iso('2025-08-08T11:12:00'),
+      updated_at: iso('2025-08-08T11:12:00'),
+    },
+  ],
+  301: [
+    {
+      id: 5101,
+      post_id: 301,
+      content: '참여하고 싶어요!',
+      author_id: 3003,
+      parent_id: null,
+      created_at: iso('2025-08-08T09:10:00'),
+      updated_at: iso('2025-08-08T09:10:00'),
+    },
+  ],
+};
+
+function makeCursorPage<T>(all: T[], cursor: number | null | undefined, size = 20): CursorPage<T> {
+  const start = cursor ? Number(cursor) : 0;
+  const items = all.slice(start, start + size);
+  const next = start + size < all.length ? start + size : null;
+  return { items, nextCursor: next };
+}
+
+export const mockFreeListCursor = (cursor: number | null | undefined) =>
+  Promise.resolve(makeCursorPage(dummyFree, cursor));
+
+export const mockShareListCursor = (cursor: number | null | undefined) =>
+  Promise.resolve(makeCursorPage(dummyShare, cursor));
+
+export const mockStudyListCursor = (cursor: number | null | undefined) =>
+  Promise.resolve(makeCursorPage(dummyStudy, cursor));
+
+// ---------- 더미 좋아요 상태 ----------
+const likeStore = new Map<number, Set<number>>(); // postId -> Set<userId>
+export const mockReadLikeCount = async (postId: number) => ({
+  count: likeStore.get(postId)?.size ?? 0,
+});
+export const mockLikeStatus = async (postId: number, userId?: number) => ({
+  liked: !!userId && likeStore.get(postId)?.has(userId) === true,
+});
+export const mockToggleLike = async (postId: number, userId?: number) => {
+  if (!userId) return;
+  const set = likeStore.get(postId) ?? new Set<number>();
+  set.has(userId) ? set.delete(userId) : set.add(userId);
+  likeStore.set(postId, set);
+};
+
+// ---------- 단건 조회/댓글/작성 모킹 ----------
+export const mockGetFree = async (id: number) => {
+  const d = dummyFree.find((x) => x.id === id);
+  if (!d) throw new Error('not found');
+  return d;
+};
+export const mockGetShare = async (id: number) => {
+  const d = dummyShare.find((x) => x.id === id);
+  if (!d) throw new Error('not found');
+  return d;
+};
+export const mockGetStudy = async (id: number) => {
+  const d = dummyStudy.find((x) => x.id === id);
+  if (!d) throw new Error('not found');
+  return d;
+};
+
+export const mockListComments = async (postId: number): Promise<CommentTreeItem[]> => {
+  return dummyComments[postId] ? [...dummyComments[postId]] : [];
+};
+
+export const mockCreateComment = async (
+  postId: number,
+  content: string,
+  userId: number,
+  parentId?: number,
+): Promise<CommentTreeItem> => {
+  const list = (dummyComments[postId] = dummyComments[postId] ?? []);
+  const nextId = Math.max(0, ...list.map((c) => c.id)) + 1;
+  const now = new Date().toISOString();
+  const item: CommentTreeItem = {
+    id: nextId,
+    post_id: postId,
+    content,
+    author_id: userId,
+    parent_id: parentId ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+  list.push(item);
+  return item;
+};
 
 export const dummyPosts: Post[] = [
   {
@@ -11,9 +205,9 @@ export const dummyPosts: Post[] = [
     category: 'share',
     content: 'React 공식 문서, 강의, 유튜브 모음입니다.',
     createdAt: '2025-08-06',
-    viewCount: 120,
-    likeCount: 15,
-    commentCount: 3,
+    views: 1220,
+    likes: 115,
+    comments: 53,
   },
   {
     postId: 2,
@@ -23,9 +217,9 @@ export const dummyPosts: Post[] = [
     category: 'free',
     content: '밖에 나갔다가 익을 뻔',
     createdAt: '2025-08-06',
-    viewCount: 88,
-    likeCount: 4,
-    commentCount: 0,
+    views: 1204,
+    likes: 154,
+    comments: 34,
   },
   {
     postId: 3,
@@ -35,9 +229,9 @@ export const dummyPosts: Post[] = [
     category: 'study',
     content: '기초부터 실전까지 함께해요!',
     createdAt: '2025-08-06',
-    viewCount: 230,
-    likeCount: 22,
-    commentCount: 7,
+    views: 1220,
+    likes: 125,
+    comments: 23,
     recruitStart: '2025-08-07',
     recruitEnd: '2025-08-15',
     studyStart: '2025-08-17',

--- a/src/community/api/community.ts
+++ b/src/community/api/community.ts
@@ -12,6 +12,25 @@ import {
   CommentResponseDTO,
 } from './types';
 
+export type CommentTreeItem = {
+  id: number;
+  post_id: number;
+  content: string;
+  author_id: number;
+  parent_id: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function listComments(postId: number): Promise<CommentTreeItem[]> {
+  try {
+    return await http<CommentTreeItem[]>(`/api/community/post/${postId}/comments`);
+  } catch (e: any) {
+    if (String(e?.message || '').startsWith('404')) return [];
+    throw e;
+  }
+}
+
 type Category = 'all' | 'free' | 'share' | 'study';
 
 export type CursorPage<T> = {

--- a/src/community/category/CommunityFree.tsx
+++ b/src/community/category/CommunityFree.tsx
@@ -1,6 +1,70 @@
-const CommunityFree = () => {
-  return;
-  <></>;
-};
+import { useInfiniteQuery, QueryFunctionContext } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import type { FreePostResponseDTO } from '../api/types';
+import PostCard, { Post } from '../components/Postcard';
+import { mockFreeListCursor } from '../__mock__/dummyPost';
 
-export default CommunityFree;
+type CursorPage<T> = { items: T[]; nextCursor: number | null };
+type QK = readonly ['mock', 'free', 'cursor'];
+
+export default function CommunityFree() {
+  const navigate = useNavigate();
+  const currentUserId = 1001;
+
+  const q = useInfiniteQuery<
+    CursorPage<FreePostResponseDTO>,
+    Error,
+    FreePostResponseDTO[],
+    QK,
+    number | null
+  >({
+    queryKey: ['mock', 'free', 'cursor'] as const,
+    initialPageParam: null,
+    queryFn: ({ pageParam }: QueryFunctionContext<QK, number | null>) =>
+      mockFreeListCursor(pageParam),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    select: (data) => data.pages.flatMap((p) => p.items),
+  });
+
+  const items = q.data ?? [];
+
+  if (q.status === 'pending') return <div className="p-6">로딩중…</div>;
+  if (q.status === 'error') return <div className="p-6 text-red-600">불러오기 실패</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.map((dto) => {
+        const post: Post = {
+          postId: dto.id,
+          title: dto.title,
+          author: `user#${dto.author_id}`,
+          authorId: dto.author_id,
+          category: 'free',
+          content: dto.content,
+          createdAt: dto.created_at,
+          views: dto.views,
+          likes: 0,
+          comments: 0,
+        };
+        return (
+          <PostCard
+            key={post.postId}
+            post={post}
+            currentUserId={currentUserId}
+            onClick={(id) => navigate(`/community/free/${id}`)}
+          />
+        );
+      })}
+
+      {q.hasNextPage && (
+        <button
+          onClick={() => q.fetchNextPage()}
+          disabled={q.isFetchingNextPage}
+          className="block mx-auto mt-2 px-4 py-2 rounded-xl shadow hover:shadow-md"
+        >
+          {q.isFetchingNextPage ? '불러오는 중…' : '더 불러오기'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/community/category/CommunityShare.tsx
+++ b/src/community/category/CommunityShare.tsx
@@ -1,6 +1,70 @@
-const CommunityShare = () => {
-  return;
-  <></>;
-};
+import { useInfiniteQuery, QueryFunctionContext } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { mockShareListCursor } from '../__mock__/dummyPost';
+import type { SharePostResponseDTO } from '../api/types';
+import PostCard, { Post } from '../components/Postcard';
 
-export default CommunityShare;
+type CursorPage<T> = { items: T[]; nextCursor: number | null };
+type QK = readonly ['mock', 'share', 'cursor'];
+
+export default function CommunityShare() {
+  const navigate = useNavigate();
+  const currentUserId = 1001;
+
+  const q = useInfiniteQuery<
+    CursorPage<SharePostResponseDTO>,
+    Error,
+    SharePostResponseDTO[],
+    QK,
+    number | null
+  >({
+    queryKey: ['mock', 'share', 'cursor'] as const,
+    initialPageParam: null,
+    queryFn: ({ pageParam }: QueryFunctionContext<QK, number | null>) =>
+      mockShareListCursor(pageParam),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    select: (data) => data.pages.flatMap((p) => p.items),
+  });
+
+  const items = q.data ?? [];
+
+  if (q.status === 'pending') return <div className="p-6">로딩중…</div>;
+  if (q.status === 'error') return <div className="p-6 text-red-600">불러오기 실패</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.map((dto) => {
+        const post: Post = {
+          postId: dto.id,
+          title: dto.title,
+          author: `user#${dto.author_id}`,
+          authorId: dto.author_id,
+          category: 'share',
+          content: dto.content,
+          createdAt: dto.created_at,
+          views: dto.views,
+          likes: 0,
+          comments: 0,
+        };
+        return (
+          <PostCard
+            key={post.postId}
+            post={post}
+            currentUserId={currentUserId}
+            onClick={(id) => navigate(`/community/share/${id}`)}
+          />
+        );
+      })}
+
+      {q.hasNextPage && (
+        <button
+          onClick={() => q.fetchNextPage()}
+          disabled={q.isFetchingNextPage}
+          className="block mx-auto mt-2 px-4 py-2 rounded-xl shadow hover:shadow-md"
+        >
+          {q.isFetchingNextPage ? '불러오는 중…' : '더 불러오기'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/community/category/CommunityStudy.tsx
+++ b/src/community/category/CommunityStudy.tsx
@@ -1,6 +1,76 @@
-const CommunityStudy = () => {
-  return;
-  <></>;
-};
+import { useInfiniteQuery, QueryFunctionContext } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { mockStudyListCursor } from '../__mock__/dummyPost';
+import type { StudyPostResponseDTO } from '../api/types';
+import PostCard, { Post } from '../components/Postcard';
 
-export default CommunityStudy;
+type CursorPage<T> = { items: T[]; nextCursor: number | null };
+type QK = readonly ['mock', 'study', 'cursor'];
+
+export default function CommunityStudy() {
+  const navigate = useNavigate();
+  const currentUserId = 1001;
+
+  const q = useInfiniteQuery<
+    CursorPage<StudyPostResponseDTO>,
+    Error,
+    StudyPostResponseDTO[],
+    QK,
+    number | null
+  >({
+    queryKey: ['mock', 'study', 'cursor'] as const,
+    initialPageParam: null,
+    queryFn: ({ pageParam }: QueryFunctionContext<QK, number | null>) =>
+      mockStudyListCursor(pageParam),
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    select: (data) => data.pages.flatMap((p) => p.items),
+  });
+
+  const items = q.data ?? [];
+
+  if (q.status === 'pending') return <div className="p-6">로딩중…</div>;
+  if (q.status === 'error') return <div className="p-6 text-red-600">불러오기 실패</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.map((dto) => {
+        const post: Post = {
+          postId: dto.id,
+          title: dto.title,
+          author: `user#${dto.author_id}`,
+          authorId: dto.author_id,
+          category: 'study',
+          content: dto.content,
+          createdAt: dto.created_at,
+          views: dto.views,
+          likes: 0,
+          comments: 0,
+
+          recruitStart: dto.study_recruitment.recruit_start,
+          recruitEnd: dto.study_recruitment.recruit_end,
+          studyStart: dto.study_recruitment.study_start,
+          studyEnd: dto.study_recruitment.study_end,
+          maxMembers: dto.study_recruitment.max_member,
+        };
+        return (
+          <PostCard
+            key={post.postId}
+            post={post}
+            currentUserId={currentUserId}
+            onClick={(id) => navigate(`/community/study/${id}`)}
+          />
+        );
+      })}
+
+      {q.hasNextPage && (
+        <button
+          onClick={() => q.fetchNextPage()}
+          disabled={q.isFetchingNextPage}
+          className="block mx-auto mt-2 px-4 py-2 rounded-xl shadow hover:shadow-md"
+        >
+          {q.isFetchingNextPage ? '불러오는 중…' : '더 불러오기'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/community/form/EditPost.tsx
+++ b/src/community/form/EditPost.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient, QueryFunctionContext } from '@tanstack/react-query';
+
+import PostForm, { PostFormValues } from './PostForm';
+import {
+  getFreePost,
+  getSharePost,
+  getStudyPost,
+  patchFreePost,
+  patchSharePost,
+  patchStudyPost,
+} from '../api/community';
+import type {
+  FreePostResponseDTO,
+  SharePostResponseDTO,
+  StudyPostResponseDTO,
+  FreePostUpdateRequestDTO,
+  SharePostUpdateRequestDTO,
+  StudyPostUpdateRequestDTO,
+} from '../api/types';
+
+type Cat = 'free' | 'share' | 'study';
+
+const toISODate = (d?: string) => (d ? new Date(`${d}T00:00:00`).toISOString() : undefined);
+
+const toInputDate = (iso?: string | null) => {
+  if (!iso) return '';
+  const s = String(iso);
+  const i = s.indexOf('T');
+  return i > 0 ? s.slice(0, i) : s.slice(0, 10);
+};
+
+export default function EditPost() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const { category: catFromParams, id: idParam } = useParams<{ category?: Cat; id?: string }>();
+  const [sp] = useSearchParams();
+  const cat: Cat = (catFromParams as Cat) ?? ((sp.get('category') as Cat) || 'free');
+  const postId = Number(idParam ?? sp.get('id') ?? NaN);
+
+  const currentUserId = 1001;
+
+  type QK = readonly ['post', Cat, number];
+
+  const q = useQuery<
+    FreePostResponseDTO | SharePostResponseDTO | StudyPostResponseDTO,
+    Error,
+    FreePostResponseDTO | SharePostResponseDTO | StudyPostResponseDTO,
+    QK
+  >({
+    queryKey: ['post', cat, postId] as const,
+    enabled: Number.isFinite(postId),
+    queryFn: ({ queryKey }: QueryFunctionContext<QK>) => {
+      const [, category, id] = queryKey;
+      if (category === 'free') return getFreePost(id);
+      if (category === 'share') return getSharePost(id);
+      return getStudyPost(id);
+    },
+  });
+
+  const initialValues: Partial<PostFormValues> | undefined = useMemo(() => {
+    const data = q.data;
+    if (!data) return undefined;
+
+    if (cat === 'free') {
+      const d = data as FreePostResponseDTO;
+      return {
+        category: 'free',
+        title: d.title,
+        content: d.content,
+      };
+    }
+    if (cat === 'share') {
+      const d = data as SharePostResponseDTO;
+      return {
+        category: 'share',
+        title: d.title,
+        content: d.content,
+      };
+    }
+
+    const d = data as StudyPostResponseDTO;
+    return {
+      category: 'study',
+      title: d.title,
+      content: d.content,
+      recruitStart: toInputDate(d.study_recruitment.recruit_start),
+      recruitEnd: toInputDate(d.study_recruitment.recruit_end),
+      studyStart: toInputDate(d.study_recruitment.study_start),
+      studyEnd: toInputDate(d.study_recruitment.study_end),
+      maxMembers: d.study_recruitment.max_member,
+    };
+  }, [q.data, cat]);
+
+  const [shareFileUrl, setShareFileUrl] = useState<string>('');
+  const [freeImageUrl, setFreeImageUrl] = useState<string>('');
+
+  useMemo(() => {
+    if (!q.data) return;
+    if (cat === 'share') {
+      const d = q.data as SharePostResponseDTO;
+      setShareFileUrl(d.data_share?.file_url ?? '');
+    } else if (cat === 'free') {
+      const d = q.data as FreePostResponseDTO;
+      setFreeImageUrl(d.free_board?.image_url ?? '');
+    }
+  }, [q.data, cat]);
+
+  const mut = useMutation({
+    mutationFn: async (v: PostFormValues) => {
+      if (cat === 'free') {
+        const body: FreePostUpdateRequestDTO = {
+          title: v.title,
+          content: v.content,
+        };
+        return await patchFreePost(postId, body, currentUserId);
+      }
+      if (cat === 'share') {
+        const body: SharePostUpdateRequestDTO = {
+          title: v.title,
+          content: v.content,
+          file_url: shareFileUrl || null,
+        };
+        return await patchSharePost(postId, body, currentUserId);
+      }
+      const body: StudyPostUpdateRequestDTO = {
+        title: v.title,
+        content: v.content,
+        recruit_start: toISODate(v.recruitStart),
+        recruit_end: toISODate(v.recruitEnd),
+        study_start: toISODate(v.studyStart),
+        study_end: toISODate(v.studyEnd),
+        max_member: v.maxMembers,
+      };
+      return await patchStudyPost(postId, body, currentUserId);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['post', cat, postId] });
+      navigate(`/community/${cat}/${postId}`);
+    },
+  });
+
+  const handleSubmit = useCallback(
+    async (v: PostFormValues) => {
+      const fixed: PostFormValues = { ...v, category: cat };
+      try {
+        await mut.mutateAsync(fixed);
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [mut, cat],
+  );
+
+  if (!Number.isFinite(postId)) {
+    return <div className="p-6 text-red-600">잘못된 주소입니다. (id 누락)</div>;
+  }
+  if (q.status === 'pending') {
+    return <div className="p-6">불러오는 중…</div>;
+  }
+  if (q.status === 'error') {
+    return <div className="p-6 text-red-600">게시글을 불러오지 못했습니다.</div>;
+  }
+
+  const errorMsg = (mut.error as Error)?.message ?? '';
+
+  return (
+    <div className="p-6 max-w-[720px] mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">글 수정</h1>
+
+      <PostForm
+        initialValues={initialValues}
+        submitLabel={mut.isPending ? '저장 중…' : '저장'}
+        disabled={mut.isPending}
+        onSubmit={handleSubmit}
+      />
+
+      {cat === 'share' && (
+        <div className="space-y-2 border-t pt-4 mt-2">
+          <label className="block text-sm">첨부 파일 URL (옵션)</label>
+          <input
+            className="w-full border rounded-lg px-3 py-2"
+            placeholder="https://..."
+            value={shareFileUrl}
+            onChange={(e) => setShareFileUrl(e.target.value)}
+            disabled={mut.isPending}
+          />
+        </div>
+      )}
+
+      {cat === 'free' && (
+        <div className="space-y-2 border-t pt-4 mt-2">
+          <label className="block text-sm">이미지 URL (옵션)</label>
+          <input
+            className="w-full border rounded-lg px-3 py-2"
+            placeholder="https://..."
+            value={freeImageUrl}
+            onChange={(e) => setFreeImageUrl(e.target.value)}
+            disabled={mut.isPending}
+          />
+        </div>
+      )}
+
+      {errorMsg && <div className="text-red-600 text-sm">저장 실패: {errorMsg}</div>}
+    </div>
+  );
+}

--- a/src/community/post/PostDetail.tsx
+++ b/src/community/post/PostDetail.tsx
@@ -1,0 +1,395 @@
+// import { useMemo } from 'react';
+// import { useNavigate, useParams } from 'react-router-dom';
+// import { useQuery } from '@tanstack/react-query';
+
+// import {
+//   getFreePost,
+//   getSharePost,
+//   getStudyPost,
+//   listComments,
+//   deletePost,
+// } from '../api/community';
+// import type {
+//   FreePostResponseDTO,
+//   SharePostResponseDTO,
+//   StudyPostResponseDTO,
+// } from '../api/types';
+// import CommentList from './components/CommentList';
+// import CommentForm from './components/CommentForm';
+// import LikeButton from './components/LikeButton';
+
+// type Cat = 'free' | 'share' | 'study';
+
+// type VM = {
+//   id: number;
+//   title: string;
+//   content: string;
+//   authorId: number;
+//   authorName: string;
+//   createdAt: string;
+//   views: number;
+//   category: Cat;
+//   // optional
+//   imageUrl?: string | null;
+//   fileUrl?: string | null;
+//   recruitStart?: string;
+//   recruitEnd?: string;
+//   studyStart?: string;
+//   studyEnd?: string;
+//   maxMembers?: number;
+// };
+
+// const currentUserId = 1001; // 로그인 연동 전 임시
+
+// export default function PostDetail() {
+//   const nav = useNavigate();
+//   const { category, id } = useParams<{ category: Cat; id: string }>();
+//   const postId = Number(id);
+
+//   const qPost = useQuery({
+//     queryKey: ['post', category, postId] as const,
+//     enabled: !!category && Number.isFinite(postId),
+//     queryFn: async () => {
+//       if (category === 'free') return await getFreePost(postId);
+//       if (category === 'share') return await getSharePost(postId);
+//       return await getStudyPost(postId);
+//     },
+//   });
+
+//   const qComments = useQuery({
+//     queryKey: ['comments', postId] as const,
+//     enabled: Number.isFinite(postId),
+//     queryFn: () => listComments(postId),
+//   });
+
+//   const vm: VM | null = useMemo(() => {
+//     const dto = qPost.data;
+//     if (!dto || !category) return null;
+
+//     if (category === 'free') {
+//       const d = dto as FreePostResponseDTO;
+//       return {
+//         id: d.id,
+//         title: d.title,
+//         content: d.content,
+//         authorId: d.author_id,
+//         authorName: `user#${d.author_id}`,
+//         createdAt: d.created_at,
+//         views: d.views,
+//         category: 'free',
+//         imageUrl: d.free_board?.image_url ?? null,
+//       };
+//     }
+//     if (category === 'share') {
+//       const d = dto as SharePostResponseDTO;
+//       return {
+//         id: d.id,
+//         title: d.title,
+//         content: d.content,
+//         authorId: d.author_id,
+//         authorName: `user#${d.author_id}`,
+//         createdAt: d.created_at,
+//         views: d.views,
+//         category: 'share',
+//         fileUrl: d.data_share?.file_url ?? null,
+//       };
+//     }
+//     // study
+//     const d = dto as StudyPostResponseDTO;
+//     return {
+//       id: d.id,
+//       title: d.title,
+//       content: d.content,
+//       authorId: d.author_id,
+//       authorName: `user#${d.author_id}`,
+//       createdAt: d.created_at,
+//       views: d.views,
+//       category: 'study',
+//       recruitStart: d.study_recruitment.recruit_start,
+//       recruitEnd: d.study_recruitment.recruit_end,
+//       studyStart: d.study_recruitment.study_start,
+//       studyEnd: d.study_recruitment.study_end,
+//       maxMembers: d.study_recruitment.max_member,
+//     };
+//   }, [qPost.data, category]);
+
+//   if (qPost.status === 'pending') return <div className="p-6">불러오는 중…</div>;
+//   if (qPost.status === 'error' || !vm) return <div className="p-6 text-red-600">글을 불러오지 못했습니다.</div>;
+
+//   const canEdit = vm.authorId === currentUserId;
+
+//   const handleDelete = async () => {
+//     if (!confirm('정말 삭제하시겠어요?')) return;
+//     try {
+//       await deletePost(vm.id, currentUserId);
+//       nav('/community');
+//     } catch (e) {
+//       alert('삭제 실패');
+//     }
+//   };
+
+//   return (
+//     <div className="max-w-[900px] mx-auto p-4">
+//       {/* 헤더 */}
+//       <div className="bg-gray-100 rounded-2xl shadow px-6 py-5">
+//         <div className="flex items-start justify-between">
+//           <div>
+//             <div className="font-semibold text-gray-800">{vm.authorName}</div>
+//             <div className="text-xs text-gray-500">{vm.createdAt}</div>
+//           </div>
+
+//           <div className="flex items-center gap-3">
+//             <LikeButton postId={vm.id} currentUserId={currentUserId} />
+//             {canEdit && (
+//               <>
+//                 <button
+//                   className="text-sm text-gray-700 hover:text-[#0180F5]"
+//                   onClick={() => nav(`/community/${vm.category}/${vm.id}/edit`)}
+//                 >
+//                   수정
+//                 </button>
+//                 <button
+//                   className="text-sm text-gray-700 hover:text-[#0180F5]"
+//                   onClick={handleDelete}
+//                 >
+//                   삭제
+//                 </button>
+//               </>
+//             )}
+//           </div>
+//         </div>
+
+//         <h1 className="text-2xl font-bold mt-3">{vm.title}</h1>
+
+//         {/* 카테고리별 보조영역 */}
+//         {vm.category === 'study' && (
+//           <div className="mt-2 text-sm text-gray-700 space-y-1">
+//             <div>모집기간: {vm.recruitStart} ~ {vm.recruitEnd}</div>
+//             <div>스터디기간: {vm.studyStart} ~ {vm.studyEnd}</div>
+//             <div>모집인원: {vm.maxMembers}명</div>
+//           </div>
+//         )}
+//         {vm.category === 'share' && vm.fileUrl && (
+//           <div className="mt-2">
+//             <a
+//               href={vm.fileUrl}
+//               className="text-sm text-[#0180F5] underline"
+//               target="_blank" rel="noopener noreferrer"
+//             >
+//               첨부 파일 열기
+//             </a>
+//           </div>
+//         )}
+//         {vm.category === 'free' && vm.imageUrl && (
+//           <div className="mt-3">
+//             {/* eslint-disable-next-line @next/next/no-img-element */}
+//             <img src={vm.imageUrl} alt="첨부 이미지" className="rounded-xl max-h-80 object-cover" />
+//           </div>
+//         )}
+
+//         {/* 본문 */}
+//         <div className="mt-4 whitespace-pre-wrap leading-7 text-gray-800">
+//           {vm.content}
+//         </div>
+//       </div>
+
+//       {/* 댓글 */}
+//       <section className="mt-6">
+//         <CommentForm postId={vm.id} currentUserId={currentUserId} />
+//         <CommentList
+//           isLoading={qComments.status === 'pending'}
+//           items={qComments.data ?? []}
+//           postId={vm.id}
+//           currentUserId={currentUserId}
+//         />
+//       </section>
+//     </div>
+//   );
+// }
+
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import { mockGetFree, mockGetShare, mockGetStudy, mockListComments } from '../__mock__/dummyPost';
+import type { FreePostResponseDTO, SharePostResponseDTO, StudyPostResponseDTO } from '../api/types';
+
+import CommentList from './components/CommentList';
+import CommentForm from './components/CommentForm';
+import LikeButton from './components/LikeButton';
+
+type Cat = 'free' | 'share' | 'study';
+
+type VM = {
+  id: number;
+  title: string;
+  content: string;
+  authorId: number;
+  authorName: string;
+  createdAt: string;
+  views: number;
+  category: Cat;
+  imageUrl?: string | null;
+  fileUrl?: string | null;
+  recruitStart?: string;
+  recruitEnd?: string;
+  studyStart?: string;
+  studyEnd?: string;
+  maxMembers?: number;
+};
+
+const currentUserId = 1001;
+
+export default function PostDetailMock() {
+  const nav = useNavigate();
+  const { category, id } = useParams<{ category: Cat; id: string }>();
+  const postId = Number(id);
+
+  const qPost = useQuery({
+    queryKey: ['post', 'mock', category, postId] as const,
+    enabled: !!category && Number.isFinite(postId),
+    queryFn: async () => {
+      if (category === 'free') return await mockGetFree(postId);
+      if (category === 'share') return await mockGetShare(postId);
+      return await mockGetStudy(postId);
+    },
+  });
+
+  const qComments = useQuery({
+    queryKey: ['comments', 'mock', postId] as const,
+    enabled: Number.isFinite(postId),
+    queryFn: () => mockListComments(postId),
+  });
+
+  const vm: VM | null = useMemo(() => {
+    const dto = qPost.data;
+    if (!dto || !category) return null;
+
+    if (category === 'free') {
+      const d = dto as FreePostResponseDTO;
+      return {
+        id: d.id,
+        title: d.title,
+        content: d.content,
+        authorId: d.author_id,
+        authorName: `user#${d.author_id}`,
+        createdAt: d.created_at,
+        views: d.views,
+        category: 'free',
+        imageUrl: d.free_board?.image_url ?? null,
+      };
+    }
+    if (category === 'share') {
+      const d = dto as SharePostResponseDTO;
+      return {
+        id: d.id,
+        title: d.title,
+        content: d.content,
+        authorId: d.author_id,
+        authorName: `user#${d.author_id}`,
+        createdAt: d.created_at,
+        views: d.views,
+        category: 'share',
+        fileUrl: d.data_share?.file_url ?? null,
+      };
+    }
+    const d = dto as StudyPostResponseDTO;
+    return {
+      id: d.id,
+      title: d.title,
+      content: d.content,
+      authorId: d.author_id,
+      authorName: `user#${d.author_id}`,
+      createdAt: d.created_at,
+      views: d.views,
+      category: 'study',
+      recruitStart: d.study_recruitment.recruit_start,
+      recruitEnd: d.study_recruitment.recruit_end,
+      studyStart: d.study_recruitment.study_start,
+      studyEnd: d.study_recruitment.study_end,
+      maxMembers: d.study_recruitment.max_member,
+    };
+  }, [qPost.data, category]);
+
+  if (qPost.status === 'pending') return <div className="p-6">불러오는 중…</div>;
+  if (qPost.status === 'error' || !vm)
+    return <div className="p-6 text-red-600">글을 불러오지 못했습니다.</div>;
+
+  const canEdit = vm.authorId === currentUserId;
+
+  return (
+    <div className="max-w-[900px] mx-auto p-4">
+      <div className="bg-gray-100 rounded-2xl shadow px-6 py-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="font-semibold text-gray-800">{vm.authorName}</div>
+            <div className="text-xs text-gray-500">{vm.createdAt}</div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <LikeButton postId={vm.id} currentUserId={currentUserId} />
+            {canEdit && (
+              <>
+                <button
+                  className="text-sm text-gray-700 hover:text-[#0180F5]"
+                  onClick={() => nav(`/community/${vm.category}/${vm.id}/edit`)}
+                >
+                  수정
+                </button>
+                <button
+                  className="text-sm text-gray-700 hover:text-[#0180F5]"
+                  onClick={() => alert('모킹: 삭제 구현 위치')}
+                >
+                  삭제
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <h1 className="text-2xl font-bold mt-3">{vm.title}</h1>
+
+        {vm.category === 'study' && (
+          <div className="mt-2 text-sm text-gray-700 space-y-1">
+            <div>
+              모집기간: {vm.recruitStart} ~ {vm.recruitEnd}
+            </div>
+            <div>
+              스터디기간: {vm.studyStart} ~ {vm.studyEnd}
+            </div>
+            <div>모집인원: {vm.maxMembers}명</div>
+          </div>
+        )}
+        {vm.category === 'share' && vm.fileUrl && (
+          <div className="mt-2">
+            <a
+              href={vm.fileUrl}
+              className="text-sm text-[#0180F5] underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              첨부 파일 열기
+            </a>
+          </div>
+        )}
+        {vm.category === 'free' && vm.imageUrl && (
+          <div className="mt-3">
+            <img src={vm.imageUrl} alt="첨부 이미지" className="rounded-xl max-h-80 object-cover" />
+          </div>
+        )}
+
+        <div className="mt-4 whitespace-pre-wrap leading-7 text-gray-800">{vm.content}</div>
+      </div>
+
+      <section className="mt-6">
+        <CommentForm postId={vm.id} currentUserId={currentUserId} />
+        <CommentList
+          isLoading={qComments.status === 'pending'}
+          items={qComments.data ?? []}
+          postId={vm.id}
+          currentUserId={currentUserId}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/community/post/components/CommentForm.tsx
+++ b/src/community/post/components/CommentForm.tsx
@@ -1,0 +1,92 @@
+// import { useState } from 'react';
+// import { useMutation, useQueryClient } from '@tanstack/react-query';
+// import { createComment } from '../../api/community';
+
+// type Props = { postId: number; currentUserId: number; parentId?: number };
+
+// export default function CommentForm({ postId, currentUserId, parentId }: Props) {
+//   const qc = useQueryClient();
+//   const [value, setValue] = useState('');
+
+//   const mut = useMutation({
+//     mutationFn: () => createComment(postId, value.trim(), currentUserId, parentId),
+//     onSuccess: () => {
+//       setValue('');
+//       qc.invalidateQueries({ queryKey: ['comments', postId] });
+//     },
+//   });
+
+//   const disabled = mut.isPending || value.trim().length === 0;
+
+//   return (
+//     <div className="bg-gray-50 border rounded-xl p-3">
+//       <textarea
+//         className="w-full rounded-md border px-3 py-2 text-sm"
+//         rows={parentId ? 2 : 3}
+//         placeholder={parentId ? '답글을 입력하세요' : '댓글을 입력하세요'}
+//         value={value}
+//         onChange={(e) => setValue(e.target.value)}
+//         disabled={mut.isPending}
+//       />
+//       <div className="flex justify-end mt-2">
+//         <button
+//           className="px-3 py-1 rounded-lg bg-black text-white text-sm disabled:opacity-60"
+//           onClick={() => mut.mutate()}
+//           disabled={disabled}
+//         >
+//           {mut.isPending ? '등록 중…' : '등록'}
+//         </button>
+//       </div>
+//     </div>
+//   );
+// }
+
+//목 코드
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { mockCreateComment } from '../../__mock__/dummyPost';
+
+export default function CommentFormMock({
+  postId,
+  currentUserId,
+  parentId,
+}: {
+  postId: number;
+  currentUserId: number;
+  parentId?: number;
+}) {
+  const qc = useQueryClient();
+  const [value, setValue] = useState('');
+
+  const mut = useMutation({
+    mutationFn: () => mockCreateComment(postId, value.trim(), currentUserId, parentId),
+    onSuccess: () => {
+      setValue('');
+      qc.invalidateQueries({ queryKey: ['comments', 'mock', postId] });
+    },
+  });
+
+  const disabled = mut.isPending || value.trim().length === 0;
+
+  return (
+    <div className="bg-gray-50 border border-gray-500 rounded-xl p-2">
+      <textarea
+        className="w-full rounded-md border border-gray-500 px-2 py-2 text-sm"
+        rows={parentId ? 2 : 3}
+        placeholder={parentId ? '답글을 입력하세요' : '댓글을 입력하세요'}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        disabled={mut.isPending}
+      />
+      <div className="flex justify-end">
+        <button
+          className="px-4 py-1 rounded-lg bg-black text-white text-sm disabled:opacity-60"
+          onClick={() => mut.mutate()}
+          disabled={disabled}
+        >
+          {mut.isPending ? '등록 중…' : '등록'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/community/post/components/CommentItem.tsx
+++ b/src/community/post/components/CommentItem.tsx
@@ -1,0 +1,130 @@
+// import { useState } from 'react';
+// import CommentForm from './CommentForm';
+// import type { CommentTreeItem } from '../../api/community';
+
+// type NodeWithChildren = CommentTreeItem & { children?: CommentTreeItem[] };
+
+// type Props = {
+//   node: NodeWithChildren;
+//   postId: number;
+//   currentUserId: number;
+//   depth: number;
+// };
+
+// export default function CommentItem({ node, postId, currentUserId, depth }: Props) {
+//   const [replyOpen, setReplyOpen] = useState(false);
+//   const isMine = node.author_id === currentUserId;
+
+//   return (
+//     <div className={`bg-gray-100 rounded-xl px-4 py-3 shadow ${depth ? 'ml-8' : ''}`}>
+//       <div className="flex items-start justify-between">
+//         <div>
+//           <div className="text-sm font-semibold text-gray-800">user#{node.author_id}</div>
+//           <div className="text-xs text-gray-500">{node.created_at}</div>
+//         </div>
+//         <div className="flex gap-3">
+//           <button
+//             className="text-xs text-gray-600 hover:text-[#0180F5]"
+//             onClick={() => setReplyOpen((v) => !v)}
+//           >
+//             답글
+//           </button>
+//           {isMine && (
+//             <>
+//               <button className="text-xs text-gray-600 hover:text-[#0180F5]">수정</button>
+//               <button className="text-xs text-gray-600 hover:text-[#0180F5]">삭제</button>
+//             </>
+//           )}
+//         </div>
+//       </div>
+
+//       <div className="mt-2 text-sm whitespace-pre-wrap">{node.content}</div>
+
+//       {replyOpen && (
+//         <div className="mt-2">
+//           <CommentForm postId={postId} currentUserId={currentUserId} parentId={node.id} />
+//         </div>
+//       )}
+
+//       {node.children && node.children.length > 0 && (
+//         <div className="mt-2 space-y-2">
+//           {node.children.map((ch) => (
+//             <CommentItem
+//               key={ch.id}
+//               node={ch}
+//               postId={postId}
+//               currentUserId={currentUserId}
+//               depth={depth + 1}
+//             />
+//           ))}
+//         </div>
+//       )}
+//     </div>
+//   );
+// }
+
+import { useState } from 'react';
+import type { CommentTreeItem } from '../../__mock__/dummyPost';
+import CommentFormMock from './CommentForm';
+type NodeWithChildren = CommentTreeItem & { children?: CommentTreeItem[] };
+
+export default function CommentItemMock({
+  node,
+  postId,
+  currentUserId,
+  depth,
+}: {
+  node: NodeWithChildren;
+  postId: number;
+  currentUserId: number;
+  depth: number;
+}) {
+  const [replyOpen, setReplyOpen] = useState(false);
+  const isMine = node.author_id === currentUserId;
+
+  return (
+    <div className={`bg-gray-100 rounded-xl my-2 px-4 py-2 shadow ${depth ? 'ml-8' : ''}`}>
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="text-xs text-gray-500"> {node.created_at}</div>
+        </div>
+        <div className="flex gap-3">
+          <button
+            className="text-xs text-gray-600 hover:text-[#0180F5]"
+            onClick={() => setReplyOpen((v) => !v)}
+          >
+            답글
+          </button>
+          {isMine && (
+            <>
+              <button className="text-xs text-gray-600 hover:text-[#0180F5]">수정</button>
+              <button className="text-xs text-gray-600 hover:text-[#0180F5]">삭제</button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-2 text-sm whitespace-pre-wrap">{node.content}</div>
+
+      {replyOpen && (
+        <div className="mt-2">
+          <CommentFormMock postId={postId} currentUserId={currentUserId} parentId={node.id} />
+        </div>
+      )}
+
+      {node.children && node.children.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {node.children.map((ch) => (
+            <CommentItemMock
+              key={ch.id}
+              node={ch}
+              postId={postId}
+              currentUserId={currentUserId}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/community/post/components/CommentList.tsx
+++ b/src/community/post/components/CommentList.tsx
@@ -1,0 +1,89 @@
+// import type { CommentTreeItem } from '../../api/community';
+// import CommentItem from './CommentItem';
+
+// type Props = {
+//   items: CommentTreeItem[];
+//   isLoading?: boolean;
+//   postId: number;
+//   currentUserId: number;
+// };
+
+// function buildTree(flat: CommentTreeItem[]): (CommentTreeItem & { children: CommentTreeItem[] })[] {
+//   const map = new Map<number, CommentTreeItem & { children: CommentTreeItem[] }>();
+//   const roots: (CommentTreeItem & { children: CommentTreeItem[] })[] = [];
+//   flat.forEach((c) => map.set(c.id, { ...c, children: [] }));
+//   map.forEach((node) => {
+//     if (node.parent_id && map.has(node.parent_id)) map.get(node.parent_id)!.children.push(node);
+//     else roots.push(node);
+//   });
+//   roots.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+//   roots.forEach((n) => n.children.sort((a, b) => (a.created_at < b.created_at ? 1 : -1)));
+//   return roots;
+// }
+
+// export default function CommentList({ items, isLoading, postId, currentUserId }: Props) {
+//   if (isLoading) return <div className="p-4 text-sm text-gray-500">댓글 불러오는 중…</div>;
+//   const tree = buildTree(items);
+//   if (tree.length === 0)
+//     return <div className="p-4 text-sm text-gray-500">첫 댓글을 남겨보세요!</div>;
+
+//   return (
+//     <div className="space-y-3">
+//       {tree.map((n) => (
+//         <CommentItem key={n.id} node={n} postId={postId} currentUserId={currentUserId} depth={0} />
+//       ))}
+//     </div>
+//   );
+// }
+
+//목 코드
+import type { CommentTreeItem } from '../../__mock__/dummyPost';
+import CommentItemMock from './CommentItem';
+
+type Props = {
+  items: CommentTreeItem[];
+  isLoading?: boolean;
+  postId: number;
+  currentUserId: number;
+};
+
+type TreeNode = CommentTreeItem & { children: CommentTreeItem[] };
+
+function buildTree(flat: CommentTreeItem[]): TreeNode[] {
+  const map = new Map<number, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  flat.forEach((c) => map.set(c.id, { ...c, children: [] }));
+  map.forEach((node) => {
+    if (node.parent_id && map.has(node.parent_id)) {
+      map.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+
+  roots.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  roots.forEach((n) => n.children.sort((a, b) => (a.created_at < b.created_at ? 1 : -1)));
+  return roots;
+}
+
+export default function CommentListMock({ items, isLoading, postId, currentUserId }: Props) {
+  if (isLoading) return <div className="p-4 text-sm text-gray-500">댓글 불러오는 중…</div>;
+  const tree = buildTree(items);
+  if (tree.length === 0)
+    return <div className="p-4 text-sm text-gray-500">첫 댓글을 남겨보세요!</div>;
+
+  return (
+    <div className="space-y-3">
+      {tree.map((n) => (
+        <CommentItemMock
+          key={n.id}
+          node={n}
+          postId={postId}
+          currentUserId={currentUserId}
+          depth={0}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/community/post/components/LikeButton.tsx
+++ b/src/community/post/components/LikeButton.tsx
@@ -1,0 +1,90 @@
+// import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+// import { likeStatus, readLikeCount, toggleLike } from '../../api/community';
+
+// export default function LikeButton({
+//   postId,
+//   currentUserId,
+// }: {
+//   postId: number;
+//   currentUserId?: number;
+// }) {
+//   const qc = useQueryClient();
+
+//   const qStatus = useQuery({
+//     queryKey: ['like', 'status', postId, currentUserId ?? null] as const,
+//     queryFn: () => likeStatus(postId, currentUserId),
+//   });
+
+//   const qCount = useQuery({
+//     queryKey: ['like', 'count', postId] as const,
+//     queryFn: () => readLikeCount(postId),
+//   });
+
+//   const mut = useMutation({
+//     mutationFn: () => toggleLike(postId, currentUserId),
+//     onSuccess: () => {
+//       qc.invalidateQueries({ queryKey: ['like', 'status', postId, currentUserId ?? null] });
+//       qc.invalidateQueries({ queryKey: ['like', 'count', postId] });
+//     },
+//   });
+
+//   const liked = (qStatus.data as any)?.liked === true;
+//   const count = (qCount.data as any)?.count ?? 0;
+
+//   return (
+//     <button
+//       className={`px-2 py-1 rounded-lg text-sm ${liked ? 'bg-red-500 text-white' : 'bg-gray-200 text-gray-700'}`}
+//       onClick={() => mut.mutate()}
+//       disabled={mut.isPending}
+//       title={liked ? '좋아요 취소' : '좋아요'}
+//     >
+//       ❤️ {count}
+//     </button>
+//   );
+// }
+
+//목 코드
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { mockLikeStatus, mockReadLikeCount, mockToggleLike } from '../../__mock__/dummyPost';
+
+export default function LikeButtonMock({
+  postId,
+  currentUserId,
+}: {
+  postId: number;
+  currentUserId?: number;
+}) {
+  const qc = useQueryClient();
+
+  const qStatus = useQuery({
+    queryKey: ['like', 'status', 'mock', postId, currentUserId ?? null] as const,
+    queryFn: () => mockLikeStatus(postId, currentUserId),
+  });
+
+  const qCount = useQuery({
+    queryKey: ['like', 'count', 'mock', postId] as const,
+    queryFn: () => mockReadLikeCount(postId),
+  });
+
+  const mut = useMutation({
+    mutationFn: () => mockToggleLike(postId, currentUserId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['like', 'status', 'mock', postId, currentUserId ?? null] });
+      qc.invalidateQueries({ queryKey: ['like', 'count', 'mock', postId] });
+    },
+  });
+
+  const liked = (qStatus.data as any)?.liked === true;
+  const count = (qCount.data as any)?.count ?? 0;
+
+  return (
+    <button
+      className={`px-2 py-1 rounded-lg text-sm ${liked ? 'bg-red-500 text-white' : 'bg-gray-100 text-gray-700'}`}
+      onClick={() => mut.mutate()}
+      disabled={mut.isPending}
+      title={liked ? '좋아요 취소' : '좋아요'}
+    >
+      ❤️ {count}
+    </button>
+  );
+}


### PR DESCRIPTION
## 📌 개요

- 게시물 클릭시 그 게시물의 상세페이지 구현
- 댓글 , 대댓글 작성 구현

## 🔧 작업 내용

- mock 더미데이터를 이용해 카테고리 별 게시물 구현
- 게시물에 하트를 클릭 시 좋아요 적용
- 댓글 구현 ( 띄어쓰기만 있을 경우,내용을 입력하지 않은 경우 댓글 등록 방지 )

## 📎 관련 이슈

- close #56 

