### PR TITLE
[FEAT] 로그인 전 api호출로인한 401에러

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -21,17 +21,24 @@ const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isLoggedIn: false,
   isInitialized: false,
-  setAuthData: (user) =>
+  setAuthData: (user) => {
+    // 로그인 성공시 localStorage에 플래그 저장
+    localStorage.setItem('hasAuthToken', 'true');
     set({
       user,
       isLoggedIn: true,
-      isInitialized: true,
-    }),
-  logout: () =>
+      isInitialized: true, // 로그인 성공시 초기화도 완료
+    });
+  },
+  logout: () => {
+    // 로그아웃시 localStorage 플래그 제거
+    localStorage.removeItem('hasAuthToken');
     set({
       user: null,
       isLoggedIn: false,
-    }),
+      // isInitialized는 그대로 유지 (이미 초기화는 완료된 상태)
+    });
+  },
   setInitialized: () => set({ isInitialized: true }),
 }));
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -11,23 +11,28 @@ interface User {
 interface AuthState {
   user: User | null;
   isLoggedIn: boolean;
+  isInitialized: boolean;
   setAuthData: (user: User) => void;
   logout: () => void;
+  setInitialized: () => void;
 }
 
 const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isLoggedIn: false,
+  isInitialized: false,
   setAuthData: (user) =>
     set({
       user,
       isLoggedIn: true,
+      isInitialized: true,
     }),
   logout: () =>
     set({
       user: null,
       isLoggedIn: false,
     }),
+  setInitialized: () => set({ isInitialized: true }),
 }));
 
 export default useAuthStore;


### PR DESCRIPTION
## 📌 개요

- 로그인 하기 전에 myinfo에 get요청으로 401에러 발생
- 작동엔 아무이상없지만 불필요한 요청과 콘솔에 찍히는게 보기가싫음................

## 🔧 작업 내용

- 로그인 성공 후 토큰값이 있을경우에만 api요청 보내는걸로 수정하였으나.. 왜인지 없어도 계속 요청시도
- 로컬스테이지로 상태를 판별하는 방법으로 수정
(로그인 성공하여 myinfo에서 사용자정보를 받아오면 로컬스테이지 상태 변경되게)


## 📎 관련 이슈

- close #78
