### PR TITLE
[FEAT] TopWeekly api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
-        "axios": "^1.11.0",
         "@tanstack/react-query": "^5.85.3",
+        "axios": "^1.11.0",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.23.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
-    "axios": "^1.11.0",
     "@tanstack/react-query": "^5.85.3",
+    "axios": "^1.11.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.12",
     "react": "^19.1.0",

--- a/src/community/api/community.ts
+++ b/src/community/api/community.ts
@@ -13,6 +13,8 @@ import {
   Post,
   AllPostResponse,
   SearchIn,
+  TopCategory,
+  TopWeeklyResponse,
 } from './types';
 
 export type CommentTreeItem = {
@@ -260,3 +262,20 @@ export async function searchPostsAllPages(
   mapped.sort((a, b) => new Date(b.created_at).valueOf() - new Date(a.created_at).valueOf());
   return mapped;
 }
+
+// 위클리 탑5
+const TOP_WEEKLY_PATH: Record<TopCategory, string> = {
+  study: '/api/v1/community/post/study/top-weekly',
+  free: '/api/v1/community/post/free/top-weekly',
+  share: '/api/v1/community/post/share/top-weekly',
+};
+
+export async function getTopWeekly(category: TopCategory, limit = 5): Promise<TopWeeklyResponse> {
+  const path = TOP_WEEKLY_PATH[category];
+  const url = `${path}?limit=${encodeURIComponent(limit)}`;
+  return http<TopWeeklyResponse>(url);
+}
+
+export const getTopWeeklyStudy = (limit = 5) => getTopWeekly('study', limit);
+export const getTopWeeklyFree = (limit = 5) => getTopWeekly('free', limit);
+export const getTopWeeklyShare = (limit = 5) => getTopWeekly('share', limit);

--- a/src/community/api/types.ts
+++ b/src/community/api/types.ts
@@ -216,5 +216,5 @@ export interface TopWeeklyItem {
 export interface TopWeeklyResponse {
   category: TopCategory;
   count: number;
-  items: TopWeeklyItem;
+  items: TopWeeklyItem[];
 }

--- a/src/community/api/types.ts
+++ b/src/community/api/types.ts
@@ -201,3 +201,20 @@ export interface SearchPostItem {
   created_at: string;
   badge?: '모집중' | '모집완료';
 }
+
+export type TopCategory = 'study' | 'free' | 'share';
+
+export interface TopWeeklyItem {
+  post_id: number;
+  title: string;
+  category: TopCategory;
+  author_id: number; // author_id 타입 재정립 필요가 있음 일단 int로 받기.
+  total_views_7d: number;
+  created_at: string;
+}
+
+export interface TopWeeklyResponse {
+  category: TopCategory;
+  count: number;
+  items: TopWeeklyItem;
+}

--- a/src/community/components/SidebarRanking.tsx
+++ b/src/community/components/SidebarRanking.tsx
@@ -1,70 +1,83 @@
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
+import { useTopWeeklyAll } from '../hook/useTopWeekly';
+import type { TopWeeklyItem } from '../api/types';
 
-interface RankingPost {
-  id: number;
-  title: string;
-}
-
-interface SidebarRankingProps {
-  shareTop5?: RankingPost[];
-  freeTop5?: RankingPost[];
-  studyTop5?: RankingPost[];
-}
-
-const SidebarRanking = ({
-  shareTop5 = [],
-  freeTop5 = [],
-  studyTop5 = [],
-}: SidebarRankingProps) => {
+function ItemRow({ idx, item }: { idx: number; item: TopWeeklyItem }) {
   return (
-    <div className="bg-[#0180F5] text-white p-4 rounded-lg w-[240px] text-sm">
-      <div>
-        <h2> 자유 게시판 Top 5 </h2>
-        <ul>
-          {freeTop5.map((post) => (
-            <li key={post.id}>
-              <Link
-                to={`/community/post/${post.id}`}
-                className="block bg-white p-2 text-black my-1 rounded-md shadow hover:bg-gray-50"
-              >
-                {post.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h2> 자료 공유 게시판 Top 5 </h2>
-        <ul>
-          {shareTop5.map((post) => (
-            <li key={post.id}>
-              <Link
-                to={`/community/post/${post.id}`}
-                className="block bg-white p-2 text-black my-1 rounded-md shadow hover:bg-gray-50"
-              >
-                {post.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h2> 스터디 모집 게시판 Top 5 </h2>
-        <ul>
-          {studyTop5.map((post) => (
-            <li key={post.id}>
-              <Link
-                to={`/community/post/${post.id}`}
-                className="block bg-white p-2 text-black my-1 rounded-md shadow hover:bg-gray-50"
-              >
-                {post.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </div>
+    <li className="flex items-start gap-2 py-1">
+      <span className="w-5 text-sm shrink-0 text-gray-500">{idx + 1}.</span>
+      <Link
+        to={`/community/${item.category}/${item.post_id}`}
+        className="truncate hover:underline"
+        title={item.title}
+      >
+        {item.title}
+      </Link>
+      <span className="ml-auto text-xs text-gray-400">
+        {item.total_views_7d.toLocaleString()} views
+      </span>
+    </li>
   );
-};
+}
 
-export default SidebarRanking;
+function Block({
+  title,
+  items,
+  isLoading,
+  isError,
+}: {
+  title: string;
+  items?: TopWeeklyItem[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  return (
+    <section className="p-4 rounded-2xl shadow">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      {isLoading ? (
+        <ul className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <li key={i} className="h-5 animate-pulse rounded bg-gray-100" />
+          ))}
+        </ul>
+      ) : isError ? (
+        <div className="text-sm text-red-500">불러오기에 실패했어요.</div>
+      ) : items && items.length > 0 ? (
+        <ul>
+          {items.slice(0, 5).map((it, i) => (
+            <ItemRow key={it.post_id} idx={i} item={it} />
+          ))}
+        </ul>
+      ) : (
+        <div className="text-sm text-gray-400">데이터가 없어요.</div>
+      )}
+    </section>
+  );
+}
+
+export default function SidebarRanking() {
+  const { study, free, share, isLoading, isError } = useTopWeeklyAll(5);
+
+  return (
+    <aside className="space-y-4">
+      <Block
+        title="스터디 TOP 5"
+        items={study.data?.items}
+        isLoading={study.isLoading}
+        isError={!!study.error}
+      />
+      <Block
+        title="자유 TOP 5"
+        items={free.data?.items}
+        isLoading={free.isLoading}
+        isError={!!free.error}
+      />
+      <Block
+        title="자료공유 TOP 5"
+        items={share.data?.items}
+        isLoading={share.isLoading}
+        isError={!!share.error}
+      />
+    </aside>
+  );
+}

--- a/src/community/hook/useCreatePost.ts
+++ b/src/community/hook/useCreatePost.ts
@@ -38,7 +38,7 @@ export function useCreatePost(currentUserId: number) {
         category: payload.category,
         title: payload.title,
         content: payload.content,
-        user_id: 1,
+        user_id: currentUserId,
       });
 
       const postId: number = (basePost as any).id ?? (basePost as any).post_id;

--- a/src/community/hook/useTopWeekly.ts
+++ b/src/community/hook/useTopWeekly.ts
@@ -1,0 +1,39 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { TopCategory, TopWeeklyResponse } from '../api/types';
+import { getTopWeekly } from '../api/community';
+
+export const topWeeklyKeys = {
+  all: ['community', 'topWeekly'] as const,
+  list: (category: TopCategory, limit: number) =>
+    [...topWeeklyKeys.all, { category, limit }] as const,
+};
+
+//단일
+export function useTopWeekly(category: TopCategory, limit = 5) {
+  return useQuery<TopWeeklyResponse>({
+    queryKey: topWeeklyKeys.list(category, limit),
+    queryFn: () => getTopWeekly(category, limit),
+    staleTime: 1000 * 60,
+  });
+}
+
+//각 카테고리 동시
+export function useTopWeeklyAll(limit = 5) {
+  const categories: TopCategory[] = ['study', 'free', 'share'];
+  const results = useQueries({
+    queries: categories.map((c) => ({
+      queryKey: topWeeklyKeys.list(c, limit),
+      queryFn: () => getTopWeekly(c, limit),
+      staleTime: 1000 * 60,
+    })),
+  });
+  const map: Record<TopCategory, ReturnType<typeof useQuery<TopWeeklyResponse>>> = {
+    study: results[0] as any,
+    free: results[1] as any,
+    share: results[2] as any,
+  };
+  const isLoading = results.some((r) => r.isLoading);
+  const isError = results.some((r) => r.isError);
+
+  return { ...map, isLoading, isError } as const;
+}

--- a/src/community/post/components/CommentsBlock.tsx
+++ b/src/community/post/components/CommentsBlock.tsx
@@ -43,7 +43,7 @@ export default function CommentsBlock({
             }}
             aria-label="전송"
           >
-            <img src={squarePen} alt="commet button" className="w-4 h-4" />
+            <img src={squarePen} alt="comment button" className="w-4 h-4" />
           </button>
         </div>
       </div>
@@ -143,7 +143,7 @@ function ReplyEditor({
           }}
           aria-label="대댓글 전송"
         >
-          <img src={squarePen} alt="commet button" className="w-4 h-4" />
+          <img src={squarePen} alt="comment button" className="w-4 h-4" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요

- TopWeekly api 연결해야한다.

## 🔧 작업 내용

- [ ] type 및 hook 구현
- [ ] 각 게시글의 top-weekly api 호출해 연결
- [ ] 호출한 게시글을 클릭 시 해당 게시물의 id를 통해 상세 게시물로 이동
- [ ] slateTime은 1분

## 📎 관련 이슈

- close #94 


