### PR TITLE
[FEAT] mypage challenge

### DIFF
--- a/src/mypage/components/Challenge.tsx
+++ b/src/mypage/components/Challenge.tsx
@@ -85,10 +85,18 @@ export default function Challenge() {
                       {c.input_data}
                     </h4>
                     <p className="text-[.9rem] text-[#797979] m-[10px_0] truncate">
+                      {(() => {
+                        try {
+                          const data = JSON.parse(c.output_data);
+                          return data.title;
+                        } catch {
+                          return '데이터 오류';
+                        }
+                      })()}
                       {c.output_data}
                     </p>
                     <span className="text-[.8rem] text-[#c2c2c2]">
-                      {c.start_date}~{c.end_date}
+                      {c.start_date.slice(0, 10)}~{c.end_date.slice(0, 10)}
                     </span>
                   </div>
                   <div

--- a/src/mypage/components/Challenge.tsx
+++ b/src/mypage/components/Challenge.tsx
@@ -1,9 +1,9 @@
+import useAuthStore from '@src/store/authStore';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 export default function Challenge() {
-  //const userId = useAuthStore((state) => state.user?.id);
-  const userId = 30;
+  const userId = useAuthStore((state) => state.user?.id);
   const [myChallenge, setMyChallenge] = useState<StudyPlanData[]>([]);
 
   type ChallengeStatus = '진행 전' | '진행 중' | '완료';

--- a/src/mypage/components/Challenge.tsx
+++ b/src/mypage/components/Challenge.tsx
@@ -93,7 +93,6 @@ export default function Challenge() {
                           return '데이터 오류';
                         }
                       })()}
-                      {c.output_data}
                     </p>
                     <span className="text-[.8rem] text-[#c2c2c2]">
                       {c.start_date.slice(0, 10)}~{c.end_date.slice(0, 10)}

--- a/src/mypage/components/Challenge.tsx
+++ b/src/mypage/components/Challenge.tsx
@@ -1,9 +1,9 @@
-import useAuthStore from '@src/store/authStore';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 export default function Challenge() {
-  const userId = useAuthStore((state) => state.user?.id);
+  //const userId = useAuthStore((state) => state.user?.id);
+  const userId = 30;
   const [myChallenge, setMyChallenge] = useState<StudyPlanData[]>([]);
 
   type ChallengeStatus = '진행 전' | '진행 중' | '완료';
@@ -63,20 +63,15 @@ export default function Challenge() {
 
   return (
     <>
+      <h2 className="text-3xl md:text-4xl text-[#242424] tracking-[-.05rem] mb-[30px]">챌린지</h2>
       {myChallenge.length === 0 ? (
         <>
-          <h2 className="text-3xl md:text-4xl text-[#242424] tracking-[-.05rem] mb-[30px]">
-            챌린지
-          </h2>
           <p className="text-[1.2rem] text-[#999] font-light tracking-[-0.03rem] mt-5 pl-[5px]">
             등록된 챌린지가 없습니다.
           </p>
         </>
       ) : (
         <>
-          <h2 className="text-3xl md:text-4xl text-[#242424] tracking-[-.05rem] mb-[30px]">
-            챌린지
-          </h2>
           <ul>
             {myChallenge.map((c) => {
               const status = calculateStatus(c);

--- a/src/mypage/components/Challenge.tsx
+++ b/src/mypage/components/Challenge.tsx
@@ -75,6 +75,13 @@ export default function Challenge() {
           <ul>
             {myChallenge.map((c) => {
               const status = calculateStatus(c);
+              const parsedOutput = (() => {
+                try {
+                  return JSON.parse(c.output_data);
+                } catch {
+                  return '데이터 오류';
+                }
+              })();
               return (
                 <li
                   key={c.id}
@@ -82,17 +89,10 @@ export default function Challenge() {
                 >
                   <div className="w-full md:w-[80%]">
                     <h4 className="text-[1.1rem] font-bold tracking-[-.03rem] leading-[1.3]">
-                      {c.input_data}
+                      {parsedOutput.title}
                     </h4>
                     <p className="text-[.9rem] text-[#797979] m-[10px_0] truncate">
-                      {(() => {
-                        try {
-                          const data = JSON.parse(c.output_data);
-                          return data.title;
-                        } catch {
-                          return '데이터 오류';
-                        }
-                      })()}
+                      {parsedOutput.description}
                     </p>
                     <span className="text-[.8rem] text-[#c2c2c2]">
                       {c.start_date.slice(0, 10)}~{c.end_date.slice(0, 10)}


### PR DESCRIPTION
## 📌 개요

- 마이페이지 챌린지 연동

## 🔧 작업 내용

- 챌린지 시작 날짜 기준으로 '진행 전' | '진행 중' | '완료' 표시
- 제목과 내용, 날짜 표시


## 📎 관련 이슈

- close #99

