### PR TITLE
[HOTFIX] Vercel 404 Not found 에러 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/((?!.*\\.).*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 📌 개요

- Vercel 배포 과정에서 특정 URL에서 새로고침 시, 404 Not Found 에러 발생.

## 🔧 작업 내용

- [ ] vercel.json에 rewrites 추가 작업.
```
{
  "rewrites": [{ "source": "/((?!.*\\.).*)", "destination": "/index.html" }]
}
```

## 📎 관련 이슈

Closes #114 