### PR TITLE
[REFACTOR] AI API access_token 인증 추가

### DIFF
--- a/src/ai/api/cookies.ts
+++ b/src/ai/api/cookies.ts
@@ -1,0 +1,7 @@
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const m = document.cookie.match(
+    new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1') + '=([^;]*)'),
+  );
+  return m ? decodeURIComponent(m[1]) : null;
+}


### PR DESCRIPTION
## 📌 개요

- AI API access_token 인증 추가

## 🔧 작업 내용

- [x] summary_id 에서 사용되던 delete 부분의 코드 다른 곳에서도 작용되도록 작업.
- [x] AI Study Plan `POST`, `GET`, `POST`, `DELETE`
- [x] AI Summary `POST`, `GET`

## 📎 관련 이슈

Close #122 

